### PR TITLE
mockInstanceOf now accepts deep partials

### DIFF
--- a/src/tower.spec.ts
+++ b/src/tower.spec.ts
@@ -34,9 +34,9 @@ describe("tower module", () => {
       const tower = mockInstanceOf<StructureTower>({
         attack: () => OK,
         heal: () => OK,
-        pos: mockInstanceOf<RoomPosition>({
+        pos: {
           findClosestByRange: () => null
-        }),
+        },
         repair: () => OK
       });
       runTower(tower);


### PR DESCRIPTION
(no need to nest calls to it anymore)