### PR TITLE
Downgrade @types/lodash to 3.10.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
   "homepage": "https://github.com/screepers/screeps-typescript-starter#readme",
   "devDependencies": {
     "@types/jest": "^24.0.15",
-    "@types/lodash": "^3.10.1",
+    "@types/lodash": "3.10.2",
     "@types/node": "^10.5.5",
     "@types/screeps": "^3.0.0",
     "@typescript-eslint/eslint-plugin": "^2.17.0",


### PR DESCRIPTION
`@types/lodash` 3.10.3 is incompatible as discussed in #typescript on Slack.